### PR TITLE
Update huggingface_deploy.yml

### DIFF
--- a/.github/workflows/huggingface_deploy.yml
+++ b/.github/workflows/huggingface_deploy.yml
@@ -1,4 +1,3 @@
-# .github/workflows/huggingface-deploy.yml
 name: Huggingface Deployment
 
 on:
@@ -13,23 +12,33 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
+      with:
+        ref: ${{ github.sha }}  # Pin to specific commit
 
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: '3.8'
 
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    
+
     - name: Authenticate with Huggingface
-      run: |
-        huggingface-cli login --token ${{ secrets.HUGGINGFACE_TOKEN }}
+      run: huggingface-cli login --token ${{ secrets.HUGGINGFACE_TOKEN }}
 
     - name: Deploy to Huggingface
       run: |
         huggingface-cli repo create my-streamlit-app --type=space --private
         huggingface-cli repo upload --repo-id Canstralian/my-streamlit-app app.py requirements.txt
         huggingface-cli space hardware --repo-id Canstralian/my-streamlit-app --hardware cpu-basic
+      continue-on-error: true  # Allow workflow to continue even if deployment fails


### PR DESCRIPTION
## Summary by Sourcery

Update the Hugging Face deployment workflow to pin the checkout to the specific commit being deployed, cache pip dependencies, and streamline the deployment commands.

CI:
- Pin checkout to the commit SHA during deployment.
- Cache pip dependencies to speed up the workflow.
- Simplify Hugging Face CLI commands.